### PR TITLE
:sparkles: セットポイント更新アルゴリズムの改善

### DIFF
--- a/Mugi.h
+++ b/Mugi.h
@@ -34,8 +34,9 @@ class Mugi: public BakkesMod::Plugin::BakkesModPlugin
 	void onGoal(ActorWrapper caller);
 	void initSocket();
 	void endSocket();
-	void calcSetPoint(ServerWrapper sw);
-	void resetSetPoint(ServerWrapper sw);
+//	void calcSetPoint(ServerWrapper sw);
+//	void resetSetPoint(ServerWrapper sw);
+	void sendTeamNames(ServerWrapper);
 	bool sendSocket(std::string);
 	void endGame(std::string);
 
@@ -73,6 +74,7 @@ private:
 	std::unordered_map<std::string, std::string> OwnerTeamMap;
 	struct s_currentSetPoint currentSetPoint;
 	struct s_preTeamName preTeamName;
+	std::string preMatchId;
 
 	int Boosts[10];
 	int botIndex[6] = { 0,0,0,0,0,0 };

--- a/version.h
+++ b/version.h
@@ -2,7 +2,7 @@
 #define VERSION_MAJOR 1
 #define VERSION_MINOR 0
 #define VERSION_PATCH 0
-#define VERSION_BUILD 187
+#define VERSION_BUILD 198
 
 #define stringify(a) stringify_(a)
 #define stringify_(a) #a


### PR DESCRIPTION
cmd:"teamNames"
Mocaのほうでも同時に修正，Debug完了 #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced functionality to retrieve and send team names and match IDs during the season intro scene.
- **Enhancements**
	- Improved game start and end workflows to handle initial and final conditions more smoothly.
- **Documentation**
	- Updated build version number in system documentation for better tracking and compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->